### PR TITLE
商品出品のバリデーションの設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-
   def set_parents
     @parents = Category.where(ancestry: nil)
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_parents, only: [:index,:new,:show]
+  before_action :set_parents, only: [:index,:new,:show,:create]
   before_action :authenticate_user!, only: [:new] #ログインしているユーザーだけ出品画面に遷移できる
   PER = 6
   def index
@@ -8,7 +8,6 @@ class ItemsController < ApplicationController
 
   def new
     @item = Item.new
-    
   end
 
   def show

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-
-before_action :set_parents, only: [:index,:new]
+  before_action :set_parents, only: [:index,:new,:show]
+  before_action :authenticate_user!, only: [:new] #ログインしているユーザーだけ出品画面に遷移できる
   PER = 6
   def index
     @items = Item.where(selling_status: 0).page(params[:page]).per(PER).order('created_at DESC')
@@ -36,11 +36,5 @@ before_action :set_parents, only: [:index,:new]
   def item_params
     params.require(:item).permit(:name,:description,:status,:is_bear_shipping_cost,:region,:period,:price,:selling_status,:category_id,:brand_id,item_images: []).merge(user_id:current_user.id)
   end
-
-  def set_parents
-    @parents = Category.where(ancestry: nil)
-  end
-  
-
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :set_parents, only: [:index,:new,:show,:create]
-  before_action :authenticate_user!, only: [:new] #ログインしているユーザーだけ出品画面に遷移できる
+  before_action :authenticate_user!, only: [:new] #ログインしていないユーザーはnewアクションの前にログイン画面に遷移
   PER = 6
   def index
     @items = Item.where(selling_status: 0).page(params[:page]).per(PER).order('created_at DESC')

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :set_parents, only: [:index,:new,:show] #applicationControllerを継承しているのでこのコントローラで定義しなくてもset_paramsメソッドは使えます。
   def show
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,11 +14,7 @@ class Item < ApplicationRecord
   validate :image_presence
 
   def image_presence
-    if item_images.attached?
-      if !image.content_type.in?(%('image/jpeg image/png'))
-        errors.add(:item_images, 'にはjpegまたはpngファイルを添付してください')
-      end
-    else
+    if !item_images.attached?
       errors.add(:item_images, 'ファイルを添付してください')
     end
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,25 @@
 class Item < ApplicationRecord
   belongs_to :user
-  validates :price, presence: true
   has_many_attached :item_images
+
+  ##########validation####################
+  validates :name, presence: true
+  validates :description, presence: true
+  validates :is_bear_shipping_cost, presence: true
+  validates :period, presence: true
+  validates :price, presence: true
+  validates :category_id, presence: true
+  validates :brand_id, presence: true
+  validates :status, presence: true
+  validate :image_presence
+
+  def image_presence
+    if item_images.attached?
+      if !image.content_type.in?(%('image/jpeg image/png'))
+        errors.add(:item_images, 'にはjpegまたはpngファイルを添付してください')
+      end
+    else
+      errors.add(:item_images, 'ファイルを添付してください')
+    end
+  end
 end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -9,6 +9,7 @@
       %h1 商品の情報を入力
       =form_with model: @item,local:true do |f|
         .imege-upload
+          = render 'shared/error_messages', model: f.object
           .section
             %h2 出品画像
             %span 必須

--- a/app/views/shared/_error_messages.html.haml
+++ b/app/views/shared/_error_messages.html.haml
@@ -1,0 +1,5 @@
+- if model.errors.any?
+  .alert.alert-warning
+    %ul
+      - model.errors.full_messages.each do |message|
+        %li= message


### PR DESCRIPTION
# What
商品出品のバリデーションの設定
未ログインユーザーは商品投稿画面の前にログイン画面に遷移させる

shared/_error_messagesにエラーメッセージ表示テンプレートを作成
Viewから = render 'shared/error_messages', model: f.objectでテンプレートを呼び出してエラーメッセージを表示する。

# Why
商品出品時にエラーが起こらないようにするため