### PR TITLE
商品詳細画面の調整

### DIFF
--- a/app/assets/stylesheets/_show.scss
+++ b/app/assets/stylesheets/_show.scss
@@ -102,7 +102,6 @@
       position: absolute;
       top: 30px;
       background-color: $furima-red;
-      // background-color: #fff;
       width: 100%;
       padding: 20px;
       textarea{
@@ -151,33 +150,35 @@
 }
 .to-buy-item{
   background-color: $furima-gray;
-  a{
+
+  a {
     color: $white;
     text-decoration: none;
   }
-  button.buy-btn{
-    margin: 10px auto;
-    display: block;
-    width: 300px;
-    height: 50px;
+
+  .buy-btn {
     background-color: $furima-red;
     color: #fff;
+    display: block;
     font-size: 30px;
+    height: 50px;
+    margin: 10px auto;
     text-decoration: none;
+    width: 300px;
   }
 }
-.item-btn{
-  height: 50px;
-  width: 300px;
-  background-color:gray;
+
+.item-btn {
+  background-color: #808080;
+  display: block;
   font-size: 15px;
-  text-align: center;
+  height: 50px;
   line-height: 50px;
   margin: 10px auto;
-  display: block;
-  
+  text-align: center;
+  width: 300px;
 }
 
-a button:hover{
+a button:hover {
   cursor: pointer;
 }

--- a/app/assets/stylesheets/_show.scss
+++ b/app/assets/stylesheets/_show.scss
@@ -131,35 +131,37 @@
         justify-content: space-between;
         li.link{
           padding: 20px;
-          a{
-            color: $white;
-            text-decoration: none;
-          }
+          
         }
       }
       .link-item{
         font-size: 30px;
         padding: 20px;
-        a{
-          color: $white;
-          text-decoration: none;
-        }
+        
       }
     }
   }
 
 }
 .to-buy-item{
-  background-color: $furima-gray;
-  height: 150px;
-  width: 100%;
-  button{
+  background-color: $furima-green;
+ 
+  button.buy-btn{
     margin: 0 auto;
     display: block;
-    width: 500px;
+    width: 300px;
     height: 50px;
     background-color: $furima-red;
     color: #fff;
     font-size: 30px;
+    
+    
   }
+}
+a{
+  color: $white;
+  text-decoration: none;
+}
+a button:hover{
+  cursor: pointer;
 }

--- a/app/assets/stylesheets/_show.scss
+++ b/app/assets/stylesheets/_show.scss
@@ -30,9 +30,10 @@
     justify-content: center;
     flex-direction: column;
     &--name,h1{
-      font-size: 20px;
+      font-size: 35px;
       font-weight: bold;
       text-align: center;
+      margin: 15px;
       padding: 10px;
     }
     &--img{

--- a/app/assets/stylesheets/_show.scss
+++ b/app/assets/stylesheets/_show.scss
@@ -131,37 +131,53 @@
         justify-content: space-between;
         li.link{
           padding: 20px;
-          
+          a{
+            color: $white;
+            text-decoration: none;
+          }
         }
       }
       .link-item{
         font-size: 30px;
         padding: 20px;
-        
+        a{
+          color: $white;
+          text-decoration: none;
+        }
       }
     }
   }
 
 }
 .to-buy-item{
-  background-color: $furima-green;
- 
+  background-color: $furima-gray;
+  a{
+    color: $white;
+    text-decoration: none;
+  }
   button.buy-btn{
-    margin: 0 auto;
+    margin: 10px auto;
     display: block;
     width: 300px;
     height: 50px;
     background-color: $furima-red;
     color: #fff;
     font-size: 30px;
-    
-    
+    text-decoration: none;
   }
 }
-a{
-  color: $white;
-  text-decoration: none;
+.item-btn{
+  height: 50px;
+  width: 300px;
+  background-color:gray;
+  font-size: 15px;
+  text-align: center;
+  line-height: 50px;
+  margin: 10px auto;
+  display: block;
+  
 }
+
 a button:hover{
   cursor: pointer;
 }

--- a/app/assets/stylesheets/_show.scss
+++ b/app/assets/stylesheets/_show.scss
@@ -45,8 +45,6 @@
         justify-content: center;
         padding: 20px;
         li{
-          height: 600px;
-          width: 600px;
           padding: 10px;
           border: solid 3px #fff;
           text-align: center;
@@ -55,22 +53,9 @@
       }
     }
     &--sub-img{
-      width: 90%;
       padding: 10px;
       margin: 0 auto;
-      ul{
-        display: flex;
-        justify-content: center;
-        li{
-          height: 200px;
-          width: 200px;
-          margin-left: 15px;
-          text-align: center;
-          padding: 10px;
-          box-sizing: content-box;
-          border: solid 3px #fff;
-        }
-      }
+      
     }
     &--price{
       text-align: center;

--- a/app/assets/stylesheets/_show.scss
+++ b/app/assets/stylesheets/_show.scss
@@ -55,7 +55,6 @@
     &--sub-img{
       padding: 10px;
       margin: 0 auto;
-      
     }
     &--price{
       text-align: center;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,7 +30,6 @@ class ItemsController < ApplicationController
     current_item_index = @items_ids.index(@item.id)
     @is_first = current_item_index == 0 ? true : false
     @is_last = current_item_index == @items_ids.length - 1 ? true : false
-
     previous_index = current_item_index - 1
     next_index = current_item_index + 1
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -19,18 +19,8 @@
             =image_tag @item.item_images.first,class:"img",height:400,width:400
       .show-contents__item--sub-img
         -if @item.item_images.length > 1
-          -@item.item_images.each_with_index do |image,i|
+          -@item.item_images.drop(1).each_with_index do |image,i|
             =image_tag image, height:100, widht:100
-        -# %ul
-          -# 複数の投稿はこれからeach文で完了させます。
-          -# ※%thirdでエアラーが出る状況
-          -# %li
-          -#   =image_tag @item.item_images.second,class:"img",height:200,width:200
-          -# %li
-          -# %each
-          -#   =image_tag @item.item_images.third,class:"img",height:200,width:200
-          -# %li
-          -#   =image_tag @item.item_images.forth,class:"img",height:200,width:200
       .show-contents__item--price
         %h2 
           ="¥" + "#{@item.price.to_s(:delimited)}"
@@ -95,9 +85,10 @@
       = button_tag "購入画面へ進む",class:"buy-btn"
     - if user_signed_in? && current_user.id == @item.user_id # ログインユーザーが出品者の時に編集、削除ができる
       .edit-item
-        = link_to '商品を編集する', edit_item_path(@item.id)
+        = link_to '商品を編集する', edit_item_path(@item.id), class:"item-btn"
       .destryo-item
-        = link_to '商品を削除する', item_path(@item.id), method: :delete, data: {confirm: "#{@item.name}を削除します。よろしいですか？"}
+        = link_to '商品を削除する', item_path(@item.id), class:"item-btn",
+         method: :delete, data: {confirm: "#{@item.name}を削除します。よろしいですか？"}
 
 
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -16,7 +16,7 @@
       .show-contents__item--img
         %ul
           %li
-            = image_tag @item.item_images.first, class:"img", height:400, width:400
+            = image_tag @item.item_images.first, class:"img", height: 400, width: 400
       .show-contents__item--sub-img
         - if @item.item_images.length > 1
           - @item.item_images.drop(1).each_with_index do |image, _i|
@@ -81,7 +81,7 @@
 
   .to-buy-item
     = link_to order_path(@item.id) do
-      = button_tag "購入画面へ進む", class:"buy-btn"
+      = button_tag "購入画面へ進む", class: "buy-btn"
     - if user_signed_in? && current_user.id == @item.user_id # ログインユーザーが出品者の時に編集、削除ができる
       .edit-item
         = link_to '商品を編集する', edit_item_path(@item.id), class: "item-btn"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -91,14 +91,13 @@
               = link_to "〇〇をもっと見る", class: "link-item"
 
   .to-buy-item
-
-  = link_to order_path(@item.id) do
-    = button_tag "購入画面へ進む"
-  - if user_signed_in? && current_user.id == @item.user_id # ログインユーザーが出品者の時に編集、削除ができる
-    .edit-item
-      = link_to '商品を編集する', edit_item_path(@item.id)
-    .destryo-item
-      = link_to '商品を削除する', item_path(@item.id), method: :delete, data: {confirm: "#{@item.name}を削除します。よろしいですか？"}
+    = link_to order_path(@item.id) do
+      = button_tag "購入画面へ進む",class:"buy-btn"
+    - if user_signed_in? && current_user.id == @item.user_id # ログインユーザーが出品者の時に編集、削除ができる
+      .edit-item
+        = link_to '商品を編集する', edit_item_path(@item.id)
+      .destryo-item
+        = link_to '商品を削除する', item_path(@item.id), method: :delete, data: {confirm: "#{@item.name}を削除します。よろしいですか？"}
 
 
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -18,7 +18,10 @@
           %li
             =image_tag @item.item_images.first,class:"img",height:400,width:400
       .show-contents__item--sub-img
-        %ul
+        -if @item.item_images.length > 1
+          -@item.item_images.each_with_index do |image,i|
+            =image_tag image, height:100, widht:100
+        -# %ul
           -# 複数の投稿はこれからeach文で完了させます。
           -# ※%thirdでエアラーが出る状況
           -# %li

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -29,12 +29,12 @@
           -# %li
           -#   =image_tag @item.item_images.forth,class:"img",height:200,width:200
       .show-contents__item--price
-        %h2 ¥30000
+        %h2 
+          ="¥" + "#{@item.price.to_s(:delimited)}"
         %p (税込)送料込み
     .show-contents__info
       .show-contents__info--name
-        = @item.name
-      %h3 item.name
+        
       %table
         %tr
           %th 出品者

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -16,7 +16,7 @@
       .show-contents__item--img
         %ul
           %li
-            =image_tag @item.item_images.first,class:"img",height:600,width:600
+            =image_tag @item.item_images.first,class:"img",height:400,width:400
       .show-contents__item--sub-img
         %ul
           -# 複数の投稿はこれからeach文で完了させます。

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -16,18 +16,17 @@
       .show-contents__item--img
         %ul
           %li
-            =image_tag @item.item_images.first,class:"img",height:400,width:400
+            = image_tag @item.item_images.first, class:"img", height:400, width:400
       .show-contents__item--sub-img
-        -if @item.item_images.length > 1
-          -@item.item_images.drop(1).each_with_index do |image,i|
-            =image_tag image, height:100, widht:100
+        - if @item.item_images.length > 1
+          - @item.item_images.drop(1).each_with_index do |image, _i|
+            = image_tag image, height: 100, widht: 100
       .show-contents__item--price
-        %h2 
-          ="¥" + "#{@item.price.to_s(:delimited)}"
+        %h2
+          = "¥" + "#{@item.price.to_s(:delimited)}"
         %p (税込)送料込み
     .show-contents__info
       .show-contents__info--name
-        
       %table
         %tr
           %th 出品者
@@ -82,12 +81,12 @@
 
   .to-buy-item
     = link_to order_path(@item.id) do
-      = button_tag "購入画面へ進む",class:"buy-btn"
+      = button_tag "購入画面へ進む", class:"buy-btn"
     - if user_signed_in? && current_user.id == @item.user_id # ログインユーザーが出品者の時に編集、削除ができる
       .edit-item
-        = link_to '商品を編集する', edit_item_path(@item.id), class:"item-btn"
+        = link_to '商品を編集する', edit_item_path(@item.id), class: "item-btn"
       .destryo-item
-        = link_to '商品を削除する', item_path(@item.id), class:"item-btn",
+        = link_to '商品を削除する', item_path(@item.id), class: "item-btn",
          method: :delete, data: {confirm: "#{@item.name}を削除します。よろしいですか？"}
 
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2020_03_15_033422) do
     t.integer "region", null: false
     t.integer "period", null: false
     t.integer "price", null: false
-    t.integer "selling_status", default: 0
+    t.integer "selling_status", default: 0, null: false
     t.bigint "category_id", null: false
     t.bigint "brand_id", null: false
     t.datetime "created_at", null: false
@@ -118,8 +118,8 @@ ActiveRecord::Schema.define(version: 2020_03_15_033422) do
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
+    t.string "email", null: false
+    t.string "encrypted_password", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"


### PR DESCRIPTION
# WHAT
商品詳細画面の画像表示をメインとサブに分けて表示。
商品名、金額をDBと連携
商品購入ボタン、編集ボタン、削除ボタンをCSSで装飾

# WHY
商品詳細ページの中で出品者が投稿した画像を全て表示出来るようにするため。

