### PR TITLE
自己商品購入の禁止

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -80,8 +80,9 @@
               = link_to "〇〇をもっと見る", class: "link-item"
 
   .to-buy-item
-    = link_to order_path(@item.id) do
-      = button_tag "購入画面へ進む", class: "buy-btn"
+    - unless current_user == @item.user
+      = link_to order_path(@item.id) do
+        = button_tag "購入画面へ進む", class: "buy-btn"
     - if user_signed_in? && current_user.id == @item.user_id # ログインユーザーが出品者の時に編集、削除ができる
       .edit-item
         = link_to '商品を編集する', edit_item_path(@item.id), class: "item-btn"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -80,7 +80,7 @@
               = link_to "〇〇をもっと見る", class: "link-item"
 
   .to-buy-item
-    - unless current_user == @item.user
+    - unless current_user.id == @item.user.id
       = link_to order_path(@item.id) do
         = button_tag "購入画面へ進む", class: "buy-btn"
     - if user_signed_in? && current_user.id == @item.user_id # ログインユーザーが出品者の時に編集、削除ができる


### PR DESCRIPTION
# WHAT
商品を出品したユーザーが自分だった場合の購入ボタンの非表示

# WHY
商品詳細ページ実装の完成の定義の１つであったため