### PR TITLE
商品編集ページ画像削除部分フロント

### DIFF
--- a/app/assets/stylesheets/items/_update.scss
+++ b/app/assets/stylesheets/items/_update.scss
@@ -1,7 +1,58 @@
-.posted_image {
-  width: 100px;
-  height: 100px;
+.image_delete {
+  border: 1px solid #f5f5f5;
+  padding: 40px;
+
+  h2{
+    margin-block-start: 1em;
+    font-size: 16px;
+    font-weight: bold;
+    color: #333333;
+    text-align: left;
+  }
+  p {
+    font-size: 14px;
+    margin: 8px 0 10px;
+    color: #333333;
+  }
+
+  .posted_image {
+    width: 130px;
+    height: 130px;
+  }
+
+  .check_box_image {
+    display: inline-block;
+    margin-right: 1%;
+    border: 1px solid $letter-color;
+    background-color: $furima-gray;
+  }
 }
+
+.back-item{
+  background-color: #f5f5f5;
+  height: 100px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  a {
+    color: $white;
+    text-decoration: none;
+    margin-top: 50px;
+  }
+
+  .item-btn {
+    background-color: #808080;
+    display: block;
+    font-size: 15px;
+    height: 50px;
+    line-height: 50px;
+    margin: 0px auto;
+    text-align: center;
+    width: 300px;
+  }
+}
+
 .editted_alert{
   @include alert();
 }

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -5,11 +5,16 @@
       %h1 商品の情報を編集
 
       =form_with model: @item,local:true do |f|
-        %h2 投稿済みの画像
-        %p 削除したい画像にチェックをつけてください
-        - @item.item_images.each do |item_image|
-          = f.check_box :item_image_ids, { multiple: true, checked: item_image[:checked], disabled: item_image[:disabled], include_hidden: false }, item_image[:id]
-          = image_tag item_image, class: "posted_image"
+        .image_delete
+          %h2 投稿済みの画像 
+          %p 削除したい画像にチェックをつけてください
+          - @item.item_images.each do |item_image|
+            = label_tag do
+              .check_box_image
+                .check_box_image__check_box
+                  = f.check_box :item_image_ids, { multiple: true, checked: item_image[:checked], disabled: item_image[:disabled], include_hidden: false }, item_image[:id]
+                .check_box_image__image
+                  = image_tag item_image, class: "posted_image"
         .imege-upload
           = render 'shared/error_messages', model: f.object
           .section
@@ -79,11 +84,10 @@
             = f.text_field :price, step: 100, type: "number", min: "0", value: @item.price, placeholder: "例）300", class: 'input-price'
         .sell-item
           = f.submit "修正する", class: "sell-btn"
-        .edit-item
-          = link_to "商品ページへ戻る", item_path, class: "item-btn"
-.new-footer
-  .new-footer__logo
-    = image_tag("material/logo/logo-white.png", alt: "logo image")
-    %p © FURIMA
+  .back_button_area
+    .back-item
+      = link_to "商品ページへ戻る", item_path, class: "item-btn"
+
+= render 'shared/footer'
 
 


### PR DESCRIPTION
# What
商品編集ページ画像削除部分フロント実装

# Why
出品者のUI向上のため

[![Screenshot from Gyazo](https://gyazo.com/c854f5f3d8edd4aa26949acf3412f127/raw)](https://gyazo.com/c854f5f3d8edd4aa26949acf3412f127)