### PR TITLE
カテゴリー一覧→カテゴリー別商品一覧遷移

### DIFF
--- a/app/assets/stylesheets/categorys/_index.scss
+++ b/app/assets/stylesheets/categorys/_index.scss
@@ -36,19 +36,25 @@
 
     &__child {
       background-color: $white;
-      color: $letter-color;
       display: inline-block;
-      font-size: 15px;
-      font-weight: 600;
       padding: 30px;
       width: 700px;
       word-spacing: 5px;
+       .child-item {
+        text-decoration: none;
+        color: $letter-color;
+        font-size: 15px;
+        font-weight: 600;
+       }
     }
 
     &__indirects {
-      color: $light-blue;
       font-weight: 500;
       padding: 20px;
+       .indirects-item {
+        text-decoration: none;
+        color: $light-blue;
+       }
     }
     }
   }
@@ -57,13 +63,15 @@
 .parents {
   background-color: #f00;
   border-radius: 3px;
-  color: #fff;
   font-family: 'Source Sans Pro', Helvetica , Arial, 'æ¸¸ã‚´ã‚·ãƒƒã‚¯ä½“', 'YuGothic', 'ãƒ¡ã‚¤ãƒªã‚ª', 'Meiryo', sans-serif;
   font-size: 20px;
   font-weight: bold;
   height: 40px;
   margin-top: 30px;
   padding: 5px 20px;
-  text-decoration: none;
   width: 700px;
+    .parents-item {
+      text-decoration: none;
+      color: #fff;
+    }
 }

--- a/app/views/categorys/index.html.haml
+++ b/app/views/categorys/index.html.haml
@@ -6,14 +6,14 @@
         カテゴリー一覧
       .category-list
         - @parents.each do |parent|
-          = link_to "#{parent.name}", class: "parent_category", id: "#{parent.id}"
+          = link_to "#{parent.name}",category_path(parent.id), class: "parent_category", id: "#{parent.id}"
       - @parents.each do |parent|
         .parents
-          =  parent.name
+          = link_to parent.name, category_path(parent.id), class: "parents-item"
         .category-list__child
           - parent.children.each do |child|
-            = child.name
+            = link_to child.name, category_path(child.id), class: "child-item"
           .category-list__indirects
             - parent.indirects.each do |indirects|
-              = indirects.name
+              = link_to indirects.name, category_path(indirects.id), class: "indirects-item"
 = render "shared/footer"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -22,6 +22,10 @@
         .list-item__icon
           >
       %li.list-item
+        = link_to "カテゴリー一覧", categorys_path, class: 'mypage-list-btn'
+        .list-item__icon
+          >
+      %li.list-item
         = link_to "お届け先登録/変更", new_shipping_address_path, class: 'mypage-list-btn'
         .list-item__icon
           >


### PR DESCRIPTION
# What
マイページからカテゴリー一覧に遷移できる様にした
カテゴリーの項目をクリックするとそのカテゴリーに関連する商品一覧ページに遷移する様実装
https://gyazo.com/fa7d7b567cb6c72ff26fe00ee7b93455

# Why
商品検索の利便性向上の為
