### PR TITLE
商品詳細ページに親と祖父カテゴリー名を表示

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -40,7 +40,7 @@
         %tr
           %th カテゴリー
           %td
-            = @category.name
+            = "#{@category.parent.parent.name} > #{@category.parent.name} > #{@category.name}"
 
         %tr
           %th ブランド


### PR DESCRIPTION
# What
#96 の対応
# Why
商品がどのカテゴリに属しているかわかりづらかったため

[![Screenshot from Gyazo](https://gyazo.com/d8d38aeee90b19aa7bc7c8cdae7d1358/raw)](https://gyazo.com/d8d38aeee90b19aa7bc7c8cdae7d1358)