### PR TITLE
カテゴリー一覧画面修正

### DIFF
--- a/app/controllers/categorys_controller.rb
+++ b/app/controllers/categorys_controller.rb
@@ -8,10 +8,24 @@ class CategorysController < ApplicationController
   end
 
   def show
+    # カテゴリー名
     @category_name = Category.find(params[:id]).name
 
-    # paramsで送られてきたcategory_idと一致するかつselling_status=0(出品中)のitemを全件取得
-    @items = Item.where("category_id = :selected_category AND selling_status = 0",{selected_category: params[:id]}).page(params[:page]).per(8).order('created_at DESC')
+    # 表示する商品を格納する配列を宣言
+    @display_items = []
+
+    # selling_status = 0（出品中）の商品を全て取得
+    items = Item.where("selling_status = 0")
+
+    # カテゴリーidをinteger型にキャストして変数に格納しておく
+    category_id = (params[:id]).to_i
+
+    # 出品中の全商品の中から自身または親のカテゴリーidがcategory_idと一致するものを@display_itemsに格納する。
+    items.each do |item|
+      if item.category.id == category_id || item.category.ancestor_ids.include?(category_id)
+        @display_items << item
+      end
+    end
   end
 
   private

--- a/app/views/categorys/show.html.haml
+++ b/app/views/categorys/show.html.haml
@@ -21,6 +21,5 @@
         .no_item_alert
           = link_to "該当する商品がありません", root_path, class: "back-to-root-form-category"
   .main__content__bottom
-    -# = paginate @display_items
   
   = render "shared/footer"


### PR DESCRIPTION
# What
親カテゴリを選択した場合、その子供カテゴリーに属する商品を全て表示するように修正
#101 
# Why
ユーザーの検索性向上のため

[![Screenshot from Gyazo](https://gyazo.com/e83493f1d91e8bd65ceccbaca9b6935e/raw)](https://gyazo.com/e83493f1d91e8bd65ceccbaca9b6935e)