### PR TITLE
商品編集カテゴリー初期値の設定

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -51,6 +51,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    @category = Category.find(@item.category_id)
   end
 
   def update

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -50,13 +50,21 @@
               %span 必須
             .section
               %select#parent
-                %option{ value: 0 } #{@category.name}
+                %option{ value: 0 } #{@category.parent.parent.name}
                 - @parents.each do |category|
                   %option{ value: "#{ category.id }" } #{ category.name }
 
             .section.child-category
+              %select#edit-child
+                %option{ value: 0 } #{@category.parent.name}
+                - @parents.each do |category|
+                  %option{ value: "#{ category.id }" } #{ category.name }
 
             .section.grand-child-category
+              %select#edit-grand-child
+                %option{ value: 0 } #{@category.name}
+                - @parents.each do |category|
+                  %option{ value: "#{ category.id }" } #{ category.name }
 
             .section
               %p ブランド

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -50,7 +50,7 @@
               %span 必須
             .section
               %select#parent
-                %option{ value: 0 } 選択して下さい
+                %option{ value: 0 } #{@category.name}
                 - @parents.each do |category|
                   %option{ value: "#{ category.id }" } #{ category.name }
 


### PR DESCRIPTION
# WHAT
編集画面のカテゴリーのフォームにDBの値を反映できていない問題の対応として、フォームの初期値をDBの値にすることで解決させた
[![Screenshot from Gyazo](https://gyazo.com/4bf61e57242934c3e19c861e9c00eaf0/raw)](https://gyazo.com/4bf61e57242934c3e19c861e9c00eaf0)

# WHY
ユーザーが出品した商品のデータを編集しようとした際に登録したDBを反映させないと登録したデータがわからない為