### PR TITLE
価格入力フォーム3桁カンマ付与

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,3 +92,4 @@ gem 'active_hash'
 gem 'rubocop', require: false
 gem "font-awesome-sass"
 gem "gretel"
+gem 'autonumeric-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
       io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
+    autonumeric-rails (2.0.0.1)
+      jquery-rails (>= 2.0.2)
     aws-eventstream (1.0.3)
     aws-partitions (1.278.0)
     aws-sdk-core (3.90.1)
@@ -374,6 +376,7 @@ PLATFORMS
 DEPENDENCIES
   active_hash
   ancestry
+  autonumeric-rails
   aws-sdk-s3
   better_errors
   binding_of_caller

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,5 @@
 //= require jquery
 //= require rails-ujs
 //= require activestorage
-
+//= require autonumeric
 //= require_tree .

--- a/app/assets/javascripts/items.js.coffee
+++ b/app/assets/javascripts/items.js.coffee
@@ -1,0 +1,4 @@
+ready = ->
+  $(document).trigger('refresh_autonumeric')
+$(document).ready(ready)
+$(document).on('page:load', ready)

--- a/app/assets/javascripts/selling-price.js
+++ b/app/assets/javascripts/selling-price.js
@@ -1,10 +1,11 @@
 $(function(){
-  $('#item_price').on("input",function(){
-    var number = $('#item_price').val();
-    var price =  parseInt(number);
+  $('.input-price').on("input",function(){
+    var price = $('.input-price').val();
+    // カンマがあると下の手数料の計算がおかしくなるためここで一旦外します↓
+    var number = price.replace(/,/g, '');
     // 販売手数料、販売利益の計算
-    var commission = price  * 0.1
-    var profit = price  * 0.9
+    var commission = number  * 0.1
+    var profit = number  * 0.9
     // commissionとprofitに３桁区切りのカンマ付与
     var comma_commission = commission.toLocaleString();
     var comma_profit = profit.toLocaleString();

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -84,7 +84,7 @@
             %span 必須
           .price-input__form
             ¥
-            = f.text_field :price, step: 100, type: "number", min: "0", value: "@item.price", placeholder: "例）300", class: 'input-price'
+            = f.text_field :price, data: { autonumeric: true },value: "@item.price", placeholder: "例）300", class: 'input-price'
           .commission-box
             %p 販売手数料 (10%)
             %p.commission-input ーー


### PR DESCRIPTION
# What
autoNumericというgemを導入し、価格入力フォームに３桁区切りのカンマを付与した
https://gyazo.com/fb67c1bc15e493a225ce74a055346bec

# Why
カンマがあれば高額でも値段が一目でわかりやすい為