### PR TITLE
出品した商品一覧ページ

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
 
-  before_action :set_parents, only: [:index,:new,:show,:create, :edit]
+  before_action :set_parents, only: [:index,:new,:show,:create, :edit, :preview]
   before_action :authenticate_user!, only: [:new, :show] #ログインしていないユーザーはnewとshowアクションの前にログイン画面に遷移
   before_action :set_item, only: [:show, :edit, :update, :destroy]
 
@@ -90,6 +90,11 @@ class ItemsController < ApplicationController
     end
   end
 
+  def preview
+    @items = Item.where(selling_status: 0).order('created_at DESC')
+    @brands = Brand.all
+    @item = Item.find_by(params[:id])
+  end
   
   def search
     @categories = Category.where(ancestry: params[:id])

--- a/app/views/items/preview.html.haml
+++ b/app/views/items/preview.html.haml
@@ -1,0 +1,20 @@
+= render "shared/header"
+%main.main
+  .main__content
+    .main__content__name
+      %h1 商品一覧
+      %h2=link_to"新規投稿商品"
+
+    .main__content__items
+      - @items.each do |item|
+        .contents__list
+          .contents__list--img 
+            = link_to item_path(item.id) do
+              =image_tag item.item_images.first ,class:"img",height:200,width:240
+          .contents__list--price
+            = "¥#{item.price.to_s(:delimited)}"
+          .contents__list--name
+            =item.name
+            .contents_user
+              = "出品者: " + item.user.name + "さん"
+= render "shared/footer"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -18,7 +18,7 @@
         .list-item__icon
           >
       %li.list-item
-        = link_to "出品した商品", item_path, class: 'mypage-list-btn'
+        = link_to "出品した商品", preview_item_path, class: 'mypage-list-btn'
         .list-item__icon
           >
       %li.list-item

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@ Rails.application.routes.draw do
   root to: 'items#index'
 
   resources :items do
+    member do
+      get 'preview'
+    end
     collection do
       get 'search'
     end


### PR DESCRIPTION
# What
出品した商品一覧ページ作成
マイページから出品した商品カテゴリをクリックするとそのページに遷移するよう実装した
https://gyazo.com/4fdf90f78bc908663ca43a4af5affd81

# Why
出品した商品が一目で分かる様にしたかった為

