### PR TITLE
エラーメッセージ日本語化（カラム名修正）

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -152,6 +152,12 @@
       }
       .to-do{
         @include mypage-list;
+        
+        h2 {
+          font-size: 18px;
+          font-weight: bold;
+          color: $furima-blue;
+        }
       }
 
       .create-user a{

--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -152,11 +152,11 @@
       }
       .to-do{
         @include mypage-list;
-        
+
         h2 {
+          color: $furima-blue;
           font-size: 18px;
           font-weight: bold;
-          color: $furima-blue;
         }
       }
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -38,12 +38,12 @@ class Item < ApplicationRecord
 
     # category_idが0かnilの場合、即エラー
     if category_id == 0 || category_id == nil
-      errors.add(:category_id, 'カテゴリーが正しく選択されていません')
+      errors.add(:category_id, 'が正しく選択されていません')
     else
       # 選択されたカテゴリーが親とさらにその親を持たない場合はエラー
       selected_category = Category.find(category_id)
       if selected_category == nil || selected_category.parent == nil || selected_category.parent.parent == nil
-        errors.add(:category_id, 'カテゴリーが正しく選択されていません')
+        errors.add(:category_id, 'が正しく選択されていません')
       end
     end
 

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -17,7 +17,7 @@
         .to-mypage
           = link_to "マイページへ", user_path(current_user.id)
         .to-do
-          = link_to "やること", "#"
+          %h2 #{current_user.name}さん
         .logout-user
           = link_to "ログアウト", destroy_user_session_path, method: :delete, 
           class: "header__right--btn", id: "logout-btn" , data: {confirm: "ログアウトします。よろしいですか？"}

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,20 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+  models:
+    item: 商品
+  attributes:
+    name: 商品名
+    description: 商品詳細
+    category: カテゴリー
+    brand: ブランド
+    is_bear_shipping_cost: 送料負担
+    period: 発送日目安
+    price: 商品価格
+    status: 商品状態
+    item_images: 商品イメージ
+    category_id: カテゴリー
+    brand_id: ブランド
   date:
     abbr_day_names:
     - 日


### PR DESCRIPTION
# WHAT
・エラーメッセージの日本語化でメッセージのカラム部分が英語になってしまうのを日本語に修正
<img src="https://gyazo.com/badb357587d521183845bf24e218836e/raw" width=300px>
・トップページのやることをユーザーネームに変更
<img src="https://gyazo.com/183a76aa2257151b0e7f0ffb3377c3e5/raw" width=50%>

# WHY

・ユーザーは日本人を想定している為。
・やることの機能は実装しないこととなった為。
