### PR TITLE
送付先情報のフォームハンドリング

### DIFF
--- a/app/assets/stylesheets/_reset.scss
+++ b/app/assets/stylesheets/_reset.scss
@@ -124,3 +124,12 @@ legend {
 }
 /* YUI CSS Detection Stamp */
 #yui3-css-stamp.cssreset { display: none; }
+
+.alert li {
+  font-size: small;
+  color: red;
+}
+
+.alert li::before {
+  content: "※";
+}

--- a/app/assets/stylesheets/_reset.scss
+++ b/app/assets/stylesheets/_reset.scss
@@ -126,8 +126,8 @@ legend {
 #yui3-css-stamp.cssreset { display: none; }
 
 .alert li {
-  font-size: small;
   color: red;
+  font-size: small;
 }
 
 .alert li::before {

--- a/app/views/shipping_addresses/edit.html.haml
+++ b/app/views/shipping_addresses/edit.html.haml
@@ -7,30 +7,34 @@
     .account-pagenew
       = form_with model: @shipping_address, local: true do |f|
         .field
+          = render 'shared/error_messages', model: f.object
           .field-label
             = f.label :郵便番号
           .field-input
-            = f.text_field :postal_code, autofocus: true
+            = f.text_field :postal_code, autofocus: true,
+             placeholder:" ※半角数字７桁（例）1234567"
         .field
           .field-label
             = f.label :都道府県
           .field-input
-            = f.collection_select :prefecture, Prefecture.all, :id, :name, prompt: "選択してください", class: 'select-box', id: 'prefecture-select__box'
+            = f.collection_select :prefecture, Prefecture.all,
+             :id, :name, prompt: "選択してください", class: 'select-box', id: 'prefecture-select__box'
         .field
           .field-label
             = f.label :市区町村
           .field-input
-            = f.text_field :municipalities
+            = f.text_field :municipalities, placeholder: " (例）フリマ区ふりま町"
         .field
           .field-label
             = f.label :番地
           .field-input
-            = f.text_field :block
+            = f.text_field :block, placeholder: " （例）１丁目１番地１号"
         .field
           .field-label
             = f.label :建物名、部屋番号
           .field-input
-            = f.text_field :building_name_room_number
+            = f.text_field :building_name_room_number,
+             placeholder: "(例）FURIMAマンション１０１号室"
         .field
           .field-label
             = f.label :お届け先電話番号

--- a/app/views/shipping_addresses/edit.html.haml
+++ b/app/views/shipping_addresses/edit.html.haml
@@ -39,7 +39,8 @@
           .field-label
             = f.label :お届け先電話番号
           .field-input
-            = f.text_field :phone_number
+            = f.text_field :phone_number,
+              placeholder: " ※半角数字11桁（例）08011110000"
 
         .actions
           = f.submit "更新", class: 'btn'

--- a/app/views/shipping_addresses/new.html.haml
+++ b/app/views/shipping_addresses/new.html.haml
@@ -7,6 +7,7 @@
     .account-pagenew
       =form_with model: @shipping_address, local:true do |f|
         .field
+          = render 'shared/error_messages', model: f.object
           .field-label
             = f.label :郵便番号
           .field-input

--- a/app/views/shipping_addresses/new.html.haml
+++ b/app/views/shipping_addresses/new.html.haml
@@ -11,7 +11,7 @@
           .field-label
             = f.label :郵便番号
           .field-input
-            = f.text_field :postal_code, autofocus: true
+            = f.text_field :postal_code, autofocus: true, placeholder:" ※半角数字７桁（例）1234567"
         .field
           .field-label
             = f.label :都道府県
@@ -21,22 +21,22 @@
           .field-label
             = f.label :市区町村
           .field-input
-            = f.text_field :municipalities
+            = f.text_field :municipalities,placeholder:" (例）フリマ区ふりま町"
         .field
           .field-label
             = f.label :番地
           .field-input
-            = f.text_field :block
+            = f.text_field :block, placeholder: " （例）１丁目１番地１号"
         .field
           .field-label
             = f.label :建物名、部屋番号
           .field-input
-            = f.text_field :building_name_room_number
+            = f.text_field :building_name_room_number, placeholder: "(例）FURIMAマンション１０１号室"
         .field
           .field-label
             = f.label :お届け先電話番号
           .field-input
-            = f.text_field :phone_number
+            = f.text_field :phone_number, placeholder:" ※半角数字11桁（例）08011110000"
 
         .actions
           = f.submit "登録", class: 'btn'

--- a/app/views/shipping_addresses/new.html.haml
+++ b/app/views/shipping_addresses/new.html.haml
@@ -39,7 +39,7 @@
             = f.label :お届け先電話番号
           .field-input
             = f.text_field :phone_number,
-              placeholder:" ※半角数字11桁（例）08011110000"
+              placeholder: " ※半角数字11桁（例）08011110000"
 
         .actions
           = f.submit "登録", class: 'btn'

--- a/app/views/shipping_addresses/new.html.haml
+++ b/app/views/shipping_addresses/new.html.haml
@@ -11,7 +11,8 @@
           .field-label
             = f.label :郵便番号
           .field-input
-            = f.text_field :postal_code, autofocus: true, placeholder:" ※半角数字７桁（例）1234567"
+            = f.text_field :postal_code, autofocus: true,
+             placeholder: " ※半角数字７桁（例）1234567"
         .field
           .field-label
             = f.label :都道府県
@@ -21,7 +22,7 @@
           .field-label
             = f.label :市区町村
           .field-input
-            = f.text_field :municipalities,placeholder:" (例）フリマ区ふりま町"
+            = f.text_field :municipalities, placeholder: " (例）フリマ区ふりま町"
         .field
           .field-label
             = f.label :番地
@@ -31,12 +32,14 @@
           .field-label
             = f.label :建物名、部屋番号
           .field-input
-            = f.text_field :building_name_room_number, placeholder: "(例）FURIMAマンション１０１号室"
+            = f.text_field :building_name_room_number,
+             placeholder: "(例）FURIMAマンション１０１号室"
         .field
           .field-label
             = f.label :お届け先電話番号
           .field-input
-            = f.text_field :phone_number, placeholder:" ※半角数字11桁（例）08011110000"
+            = f.text_field :phone_number,
+              placeholder:" ※半角数字11桁（例）08011110000"
 
         .actions
           = f.submit "登録", class: 'btn'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,6 +21,10 @@ ja:
     item_images: 商品イメージ
     category_id: カテゴリー
     brand_id: ブランド
+    postal_code: 郵便番号
+    prefecture: 県名
+    municipalities: 市町村
+    block: 建物名、番地番号
   date:
     abbr_day_names:
     - 日


### PR DESCRIPTION
# WHAT
商品送付先情報の入力欄にエラー時のアラート
各フォームにplaceholderの設定をした
[![Screenshot from Gyazo](https://gyazo.com/8ccacead81dc08fd6bde14bfcd046488/raw)](https://gyazo.com/8ccacead81dc08fd6bde14bfcd046488)
# WHY
どのように入力すれば良いのか、どこが間違っているのかをユーザー目線でわかりやすくてするため